### PR TITLE
chore: use libp2p@0.30 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/vasco-santos/js-libp2p-hop-relay-server#readme",
   "dependencies": {
-    "libp2p": "libp2p/js-libp2p#0.30.x",
+    "libp2p": "^0.30.0",
     "libp2p-gossipsub": "^0.7.0",
     "libp2p-mplex": "^0.10.1",
     "libp2p-noise": "^2.0.1",


### PR DESCRIPTION
This was merged with `0.30.x` branch