### PR TITLE
fix: include peer ID in console output

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -58,7 +58,7 @@ async function main () {
 
   await relay.start()
   console.log('Relay server listening on:')
-  relay.multiaddrs.forEach((m) => console.log(m))
+  relay.multiaddrs.forEach((m) => console.log(`${m}/p2p/${relay.peerId.toB58String()}`))
 
   if (metrics) {
     log('enabling metrics')


### PR DESCRIPTION
Prior to this change the output when running was:

    Relay server listening on:
    <Multiaddr 047f000001063a9bdd03 - /ip4/127.0.0.1/tcp/15003/ws>
    <Multiaddr 047f000001061f40 - /ip4/127.0.0.1/tcp/8000>
    metrics server listening on 800

Now it includes the peer ID:

    Relay server listening on:
    /ip4/127.0.0.1/tcp/15003/ws/p2p/12D3KooWPmPb9UBSNuJwoCPU8X7qz4CqT5BxAu1JawxZFUW8FTc9
    /ip4/127.0.0.1/tcp/8000/p2p/12D3KooWPmPb9UBSNuJwoCPU8X7qz4CqT5BxAu1JawxZFUW8FTc9
    metrics server listening on 8003

It now lacks the binary representation, I don't know how important that is.